### PR TITLE
Revert "add agent env vars to fleet cluster"

### DIFF
--- a/pkg/controllers/fleetcluster/fleetcluster.go
+++ b/pkg/controllers/fleetcluster/fleetcluster.go
@@ -172,7 +172,6 @@ func (h *handler) createCluster(cluster *mgmt.Cluster, status mgmt.ClusterStatus
 		},
 		Spec: fleet.ClusterSpec{
 			KubeConfigSecret: secretName,
-			AgentEnvVars:     cluster.Spec.AgentEnvVars,
 		},
 	})
 


### PR DESCRIPTION
This reverts commit 93dd137e7786f837d51d942d462ab9303cd1a766.

https://github.com/rancher/rancher/issues/29993