### PR TITLE
Fix cluster token yaml file name

### DIFF
--- a/pkg/planner/agent.go
+++ b/pkg/planner/agent.go
@@ -2,6 +2,7 @@ package planner
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -9,7 +10,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func DownloadClusterAgentYAML(ctx context.Context, url, ca string, token string) ([]byte, error) {
+func DownloadClusterAgentYAML(ctx context.Context, url, ca string, token, clusterID string) ([]byte, error) {
 	client, err := rest.RESTClientFor(&rest.Config{
 		ContentConfig: rest.ContentConfig{
 			GroupVersion:         &schema.GroupVersion{},
@@ -24,5 +25,5 @@ func DownloadClusterAgentYAML(ctx context.Context, url, ca string, token string)
 		return nil, err
 	}
 
-	return client.Get().AbsPath("v3", "import", token+".yaml").Do(ctx).Raw()
+	return client.Get().AbsPath("v3", "import", fmt.Sprintf("%v_%v.yaml", token, clusterID)).Do(ctx).Raw()
 }

--- a/pkg/planner/planner.go
+++ b/pkg/planner/planner.go
@@ -333,11 +333,11 @@ func (p *Planner) loadClusterAgent(cluster *rkev1.RKECluster) ([]byte, error) {
 		return nil, err
 	}
 
-	for _, token := range tokens {
-		return DownloadClusterAgentYAML(p.ctx, url, ca, token.Status.Token)
+	if len(tokens) == 0 {
+		return nil, fmt.Errorf("no cluster registration token found")
 	}
 
-	return nil, fmt.Errorf("no cluster registration token found")
+	return DownloadClusterAgentYAML(p.ctx, url, ca, tokens[0].Status.Token, cluster.Spec.ManagementClusterName)
 }
 
 func (p *Planner) kubernetesVersionToImage(version string) string {


### PR DESCRIPTION
The filename for the cluster registration token was missing the cluster
ID, which caused the request to fail with an authentication error.