### PR TITLE
Add ACE support for RKE2/K3S clusters

### DIFF
--- a/charts/rancher-operator-crd/templates/crds.yaml
+++ b/charts/rancher-operator-crd/templates/crds.yaml
@@ -36,6 +36,17 @@ spec:
             kubernetesVersion:
               nullable: true
               type: string
+            localClusterAuthEndpoint:
+              properties:
+                caCerts:
+                  nullable: true
+                  type: string
+                enabled:
+                  type: boolean
+                fqdn:
+                  nullable: true
+                  type: string
+              type: object
             rancherValues:
               nullable: true
               type: object

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.0.0-20210225010648-40ee92df4aea
 	github.com/rancher/lasso v0.0.0-20210407025055-18a00567c734
 	github.com/rancher/lasso/controller-runtime v0.0.0-20210219163000-fcdfcec12969
-	github.com/rancher/norman v0.0.0-20210219183327-731b8482505c
+	github.com/rancher/norman v0.0.0-20210225010917-c7fd1e24145b
 	github.com/rancher/rancher/pkg/apis v0.0.0-20210222182625-a85f4d1f87fe
 	github.com/rancher/rancher/pkg/client v0.0.0-20210222182625-a85f4d1f87fe
 	github.com/rancher/steve v0.0.0-20210318171316-376934558c5b

--- a/go.sum
+++ b/go.sum
@@ -560,8 +560,9 @@ github.com/rancher/lasso/controller-runtime v0.0.0-20210219163000-fcdfcec12969/g
 github.com/rancher/norman v0.0.0-20200517050325-f53cae161640/go.mod h1:92rz/7QN7DOeLQZlJY/8aFBOmF085igIVguR0wpxLas=
 github.com/rancher/norman v0.0.0-20200714195611-b3163ad4ebc4/go.mod h1:W9LfZ96OfjkWSGTy2DUqYPt47Jpzrs7eM0i3AAx6fOI=
 github.com/rancher/norman v0.0.0-20200820172041-261460ee9088/go.mod h1:W9LfZ96OfjkWSGTy2DUqYPt47Jpzrs7eM0i3AAx6fOI=
-github.com/rancher/norman v0.0.0-20210219183327-731b8482505c h1:1HKsD6uKTmVcQVuwP8PsZBeNwmVI7V+Zr0pSyxzjLTE=
 github.com/rancher/norman v0.0.0-20210219183327-731b8482505c/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
+github.com/rancher/norman v0.0.0-20210225010917-c7fd1e24145b h1:4SV/mEqaGmwvAV5XIO+hRqacZR1KyW6sTqzFNIlyTAY=
+github.com/rancher/norman v0.0.0-20210225010917-c7fd1e24145b/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
 github.com/rancher/rancher/pkg/apis v0.0.0-20210222182625-a85f4d1f87fe h1:bab3kXhWkr949jOuWJpWUAOSOFhELyO0Qpk2ZvS0JVU=
 github.com/rancher/rancher/pkg/apis v0.0.0-20210222182625-a85f4d1f87fe/go.mod h1:MRfZhFmR9wcOAYtxlPF7xpUfMkNy2MeDMUFujOy40iA=
 github.com/rancher/rancher/pkg/client v0.0.0-20210222182625-a85f4d1f87fe h1:BzezMIAdELkOeFdqdz22YGo52rab05k6UCrPWHZ22is=

--- a/pkg/apis/rancher.cattle.io/v1/cluster.go
+++ b/pkg/apis/rancher.cattle.io/v1/cluster.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	v1 "github.com/rancher/rancher-operator/pkg/apis/rke.cattle.io/v1"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/wrangler/pkg/genericcondition"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -20,10 +21,11 @@ type ClusterSpec struct {
 	CloudCredentialSecretName string `json:"cloudCredentialSecretName,omitempty"`
 	KubernetesVersion         string `json:"kubernetesVersion,omitempty"`
 
-	ClusterAPIConfig *ClusterAPIConfig `json:"clusterAPIConfig,omitempty"`
-	RKEConfig        *RKEConfig        `json:"rkeConfig,omitempty"`
-	ReferencedConfig *ReferencedConfig `json:"referencedConfig,omitempty"`
-	RancherValues    v1.GenericMap     `json:"rancherValues,omitempty" wrangler:"nullable"`
+	ClusterAPIConfig         *ClusterAPIConfig           `json:"clusterAPIConfig,omitempty"`
+	RKEConfig                *RKEConfig                  `json:"rkeConfig,omitempty"`
+	ReferencedConfig         *ReferencedConfig           `json:"referencedConfig,omitempty"`
+	RancherValues            v1.GenericMap               `json:"rancherValues,omitempty" wrangler:"nullable"`
+	LocalClusterAuthEndpoint v3.LocalClusterAuthEndpoint `json:"localClusterAuthEndpoint,omitempty"`
 }
 
 type ClusterStatus struct {

--- a/pkg/apis/rancher.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/rancher.cattle.io/v1/zz_generated_deepcopy.go
@@ -125,6 +125,7 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		**out = **in
 	}
 	in.RancherValues.DeepCopyInto(&out.RancherValues)
+	out.LocalClusterAuthEndpoint = in.LocalClusterAuthEndpoint
 	return
 }
 

--- a/pkg/controllers/cluster/controller.go
+++ b/pkg/controllers/cluster/controller.go
@@ -145,6 +145,9 @@ func (h *handler) generateCluster(cluster *v1.Cluster, status v1.ClusterStatus) 
 		return h.createClusterAndDeployAgent(cluster, status)
 	default:
 		return h.createCluster(cluster, status, v3.ClusterSpec{
+			ClusterSpecBase: v3.ClusterSpecBase{
+				LocalClusterAuthEndpoint: cluster.Spec.LocalClusterAuthEndpoint,
+			},
 			ImportedConfig: &v3.ImportedConfig{},
 		})
 	}

--- a/pkg/controllers/rke/bootstrap/controller.go
+++ b/pkg/controllers/rke/bootstrap/controller.go
@@ -317,7 +317,7 @@ func (h *handler) associateMachineWithNode(_ string, bootstrap *rkev1.RKEBootstr
 
 	nodeLabelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"rke.cattle.io/machine": string(machine.GetUID())}}
 	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: labels.Set(nodeLabelSelector.MatchLabels).String()})
-	if err != nil || len(nodes.Items) == 0 {
+	if err != nil || len(nodes.Items) == 0 || nodes.Items[0].Spec.ProviderID == "" {
 		h.machines.EnqueueAfter(machine.Namespace, machine.Name, nodeErrorEnqueueTime)
 		return bootstrap, nil
 	}
@@ -349,7 +349,6 @@ func (h *handler) updateMachineJoinURL(node *corev1.Node, machine *capi.Machine,
 	}
 
 	machine.Annotations[planner.JoinURLAnnotation] = url
-	machine.Annotations["rke.cattle.io/node-ip-address"] = address
 	_, err := h.machines.Update(machine)
 	return err
 }


### PR DESCRIPTION
In order to support ACE, the webhook config is copied to the
machine and the kube-api argument is passed to the config. A
LocalClusterAuthEndpoint parameter is added to the v1 Cluster
object to allow configuration.

Issue:
https://github.com/rancher/rancher/issues/31604