### PR TITLE
Stop overwriting v3.Cluster on update

### DIFF
--- a/pkg/controllers/cluster/reference.go
+++ b/pkg/controllers/cluster/reference.go
@@ -71,7 +71,7 @@ func (h *handler) claimCluster(cluster *v1.Cluster, status v1.ClusterStatus) (*v
 		}
 		updated.Labels[claimedLabelName] = cluster.Name
 		updated.Labels[claimedLabelNamespace] = cluster.Namespace
-		return h.rclusters.Update(updated)
+		return PatchV3Cluster(h.rclusters, available, updated)
 	}
 
 	if len(available) == 0 {


### PR DESCRIPTION
If the `github.com/rancher/rancher/pkg/apis` import is out of date and
rancher-operator attempts to update a v3.Cluster object, then any new
fields added to the cluster object in Rancher are deleted when
rancher-operator tries to update the cluster.

In order to prevent this behavior, Daishan added a patch call instead.
This change moves that code to a more general location to be used in
other places where the v3.Cluster is updated.

Issue:
https://github.com/rancher/rancher/issues/31120